### PR TITLE
Use is_alive in favor of isAlive

### DIFF
--- a/func_timeout/StoppableThread.py
+++ b/func_timeout/StoppableThread.py
@@ -38,7 +38,7 @@ class StoppableThread(threading.Thread):
         '''
             _stopThread - @see StoppableThread.stop
         '''
-        if self.isAlive() is False:
+        if self.is_alive() is False:
             return True
 
         self._stderr = open(os.devnull, 'w')
@@ -120,7 +120,7 @@ class JoinThread(threading.Thread):
             # If py2, call this first to start thread termination cleanly.
             #   Python3 does not need such ( nor does it provide.. )
             self.otherThread._Thread__stop()
-        while self.otherThread.isAlive():
+        while self.otherThread.is_alive():
             # We loop raising exception incase it's caught hopefully this breaks us far out.
             ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(self.otherThread.ident), ctypes.py_object(self.exception))
             self.otherThread.join(self.repeatEvery)

--- a/func_timeout/dafunc.py
+++ b/func_timeout/dafunc.py
@@ -86,7 +86,7 @@ def func_timeout(timeout, func, args=(), kwargs=None):
     thread.join(timeout)
 
     stopException = None
-    if thread.isAlive():
+    if thread.is_alive():
         isStopped = True
 
         class FunctionTimedOutTempType(FunctionTimedOut):


### PR DESCRIPTION
`is_alive` has been added in python2.6. `isAlive` raises a `PendingDeprecationWarning` in modern pythons:
```
(...)/python3.7/site-packages/func_timeout/dafunc.py:89: PendingDeprecationWarning: isAlive() is deprecated, use is_alive() instead
    if thread.isAlive():
```

I tried to recreate docs using `mkdoc.sh` but the diff was cluttered (I suppose the original docs were generated using different version of python).