### PR TITLE
FunctionTimedOut inherits TimeoutError

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* 4.3.6 - unreleased
+
+- FunctionTimedOut inherits TimeoutError instead of BaseException
 
 * 4.3.5 - Aug 19 2019
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is the function wherein you pass the timeout, the function you want to call
 **Example**
 
 
-So, for esxample, if you have a function "doit('arg1', 'arg2')" that you want to limit to running for 5 seconds, with func\_timeout you can call it like this:
+So, for example, if you have a function "doit('arg1', 'arg2')" that you want to limit to running for 5 seconds, with func\_timeout you can call it like this:
 
 
 	from func_timeout import func_timeout, FunctionTimedOut

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ This is the function wherein you pass the timeout, the function you want to call
 **Example**
 
 
-So, for esxample, if you have a function "doit('arg1', 'arg2')" that you want to limit to running for 5 seconds, with func\_timeout you can call it like this:
+So, for example, if you have a function "doit('arg1', 'arg2')" that you want to limit to running for 5 seconds, with func\_timeout you can call it like this:
 
 
 	from func\_timeout import func\_timeout, FunctionTimedOut

--- a/func_timeout/exceptions.py
+++ b/func_timeout/exceptions.py
@@ -9,7 +9,7 @@ __all__ = ('FunctionTimedOut', 'RETRY_SAME_TIMEOUT')
 
 RETRY_SAME_TIMEOUT = 'RETRY_SAME_TIMEOUT'
 
-class FunctionTimedOut(BaseException):
+class FunctionTimedOut(TimeoutError):
     '''
         FunctionTimedOut - Exception raised when a function times out
 
@@ -51,7 +51,7 @@ class FunctionTimedOut(BaseException):
         if not msg:
             msg = self.getMsg()
 
-        BaseException.__init__(self, msg)
+        TimeoutError.__init__(self, msg)
 
         self.msg = msg
 


### PR DESCRIPTION
FunctionTimedOut should inherit TimeoutError in my opinion instead of BaseException directly. The reason for this might be user can directly catch TimeoutError without importing FunctionTimedOut first if they do not need to.

However thanks for this library, that's exactly what I was searching for.