### PR TITLE
Removes a new line (\n) symbol that is messing the logs

### DIFF
--- a/func_timeout/exceptions.py
+++ b/func_timeout/exceptions.py
@@ -73,7 +73,7 @@ class FunctionTimedOut(BaseException):
         else:
             timedOutAfterStr = "Unknown"
 
-        return 'Function %s (args=%s) (kwargs=%s) timed out after %s seconds.\n' %(timedOutFuncName, repr(self.timedOutArgs), repr(self.timedOutKwargs), timedOutAfterStr)
+        return 'Function %s (args=%s) (kwargs=%s) timed out after %s seconds. ' %(timedOutFuncName, repr(self.timedOutArgs), repr(self.timedOutKwargs), timedOutAfterStr)
 
     def retry(self, timeout=RETRY_SAME_TIMEOUT):
         '''


### PR DESCRIPTION
Logs should be recorded in a single line, but this Exceptions is generating error messages with the new line symbol `\n`, that is breaking the error message in 2 lines.

This PR removes the new line symbol from Exceptions error messages.